### PR TITLE
change: overwrite no-pluplus rule to allow it in for-loops

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+* (Change) Overwrites `no-plusplus` rule to allow `++` statements in `for`-loops
+
 ## 15.1.0
 * (Change) Defines 'vue/object-curly-spacing' as a --fix rule.
 

--- a/rules/style.js
+++ b/rules/style.js
@@ -232,6 +232,13 @@ module.exports = {
 
     // Require regex literals to be wrapped in parentheses.
     // - Force cleaner code style
-    'wrap-regex': 2
+    'wrap-regex': 2,
+
+    // overwrites rule from eslint-config-airbnb-base
+    'no-plusplus': [
+      'error', {
+        allowForLoopAfterthoughts: true,
+      }
+    ]
   }
 };


### PR DESCRIPTION
This pull requests overwrites the `no-plusplus` rule from the `eslint-config-airbnb-base`. It allows to have `i++` statements in for loops:

```js
for (let i = 0; i < 10; i++){
    // ...
}
```

I was not sure how to add a failing test for this one. If it's necessary I'm happy to research and add one.